### PR TITLE
Fix dead links and stale navbar on old portfolio pages

### DIFF
--- a/docs/aqi.html
+++ b/docs/aqi.html
@@ -794,7 +794,7 @@ AQI data + Health advice + Activity recommendations
 <section id="get-api-key" class="level3">
 <h3 class="anchored" data-anchor-id="get-api-key">Get API Key</h3>
 <ol type="1">
-<li>Sign up at <a href="https://api.api-ninjas.com">API Ninjas</a></li>
+<li>Sign up at <a href="https://api-ninjas.com">API Ninjas</a></li>
 <li>Get your free API key</li>
 <li>Set environment variable:</li>
 </ol>

--- a/website-source/aqi.qmd
+++ b/website-source/aqi.qmd
@@ -574,7 +574,7 @@ pip install aiohttp
 ```
 
 ### Get API Key
-1. Sign up at [API Ninjas](https://api.api-ninjas.com)
+1. Sign up at [API Ninjas](https://api-ninjas.com)
 2. Get your free API key
 3. Set environment variable:
 ```bash


### PR DESCRIPTION
Three sets of fixes:

**Dead link**
- The "Sign up at API Ninjas" link on aqi.html pointed to https://api.api-ninjas.com (the raw API host, 403 in a browser) instead of https://api-ninjas.com.

**Stale navbar (every old rendered page)**
- "Projects" pointed to `index.html#projects`, an anchor that no longer exists on the redesigned homepage; now `index.html#work`.
- "About Me" pointed to the orphaned old-style `about-me.html`; now routes to the homepage's About section.
- The Temp Talk entry in the Projects dropdown pointed to expired `isfarbaset.georgetown.domains` hosting; now the live GitHub Pages site.

**Homepage cleanup (docs/index.html)**
- Stripped leftover `data-comment-anchor` attributes.
- Swapped React development builds for production builds (updated SRI hashes); kills the dev-build console warning.
- Copy pass: removed em dashes, trimmed the role roller from 12 entries to 6, cut repeated "actually" and coffee references, de-buzzed the About heading and meta description, footer reduced to the copyright line.
- Verified locally: page renders, no console errors, React dev warning gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)